### PR TITLE
Fixes a problem in DefaulFSWriterImpl if no ServiceType is provided

### DIFF
--- a/client-application/client-app-fs-storage/src/main/java/eu/ecodex/connector/client/filesystem/configuration/DomibusConnectorClientFSStorageConfiguration.java
+++ b/client-application/client-app-fs-storage/src/main/java/eu/ecodex/connector/client/filesystem/configuration/DomibusConnectorClientFSStorageConfiguration.java
@@ -14,6 +14,7 @@ import eu.ecodex.connector.client.filesystem.DomibusConnectorClientFSStorage;
 import eu.ecodex.connector.client.filesystem.DomibusConnectorClientFSStorageImpl;
 import eu.ecodex.connector.client.filesystem.DomibusConnectorClientFileSystemReader;
 import eu.ecodex.connector.client.filesystem.DomibusConnectorClientFileSystemWriter;
+import eu.ecodex.connector.client.filesystem.standard.DomibusConnectorClientFSMessageProperties;
 import eu.ecodex.connector.client.filesystem.standard.reader.DefaultFSReaderImpl;
 import eu.ecodex.connector.client.filesystem.standard.writer.DefaultFSWriterImpl;
 import eu.ecodex.connector.client.storage.DomibusConnectorClientStorage;
@@ -66,13 +67,17 @@ public class DomibusConnectorClientFSStorageConfiguration {
 
     @Bean
     @ConditionalOnMissingBean({DomibusConnectorClientFileSystemReader.class})
-    public DomibusConnectorClientFileSystemReader domibusConnectorClientFileSystemReader() {
-        return new DefaultFSReaderImpl();
+    public DomibusConnectorClientFileSystemReader domibusConnectorClientFileSystemReader(
+            DomibusConnectorClientFSMessageProperties messageProperties,
+            DomibusConnectorClientFSConfigurationProperties properties) {
+        return new DefaultFSReaderImpl(messageProperties, properties);
     }
 
     @Bean
     @ConditionalOnMissingBean({DomibusConnectorClientFileSystemWriter.class})
-    public DomibusConnectorClientFileSystemWriter domibusConnectorClientFileSystemWriter() {
-        return new DefaultFSWriterImpl();
+    public DomibusConnectorClientFileSystemWriter domibusConnectorClientFileSystemWriter(
+            DomibusConnectorClientFSMessageProperties messageProperties,
+            DomibusConnectorClientFSConfigurationProperties properties) {
+        return new DefaultFSWriterImpl(messageProperties, properties);
     }
 }

--- a/client-application/client-app-fs-storage/src/main/java/eu/ecodex/connector/client/filesystem/standard/DefaultMessageProperties.java
+++ b/client-application/client-app-fs-storage/src/main/java/eu/ecodex/connector/client/filesystem/standard/DefaultMessageProperties.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
 import java.util.Properties;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -74,18 +76,18 @@ public class DefaultMessageProperties {
      * @throws RuntimeException if an I/O error occurs while storing the properties.
      */
     public void storeMessagePropertiesToFile(File messagePropertiesFile) {
-        if (!messagePropertiesFile.exists()) {
-            try {
-                messagePropertiesFile.createNewFile();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+        try {
+            Files.createFile(messagePropertiesFile.toPath());
+        } catch (FileAlreadyExistsException fileAlreadyExistsException) {
+            //we are ignoring this one
+        } catch (IOException ioException) {
+            throw new RuntimeException("Failed to create messagePropertiesFile", ioException);
         }
 
         try (var fos = new FileOutputStream(messagePropertiesFile)) {
             messageProperties.store(fos, null);
         } catch (IOException e1) {
-            throw new RuntimeException(e1);
+            throw new RuntimeException("Failed to write messagePropertiesFile",e1);
         }
     }
 }

--- a/client-application/client-app-fs-storage/src/main/java/eu/ecodex/connector/client/filesystem/standard/reader/DefaultFSReaderImpl.java
+++ b/client-application/client-app-fs-storage/src/main/java/eu/ecodex/connector/client/filesystem/standard/reader/DefaultFSReaderImpl.java
@@ -33,10 +33,9 @@ import eu.ecodex.connector.domain.transition.tools.ConversionTools;
 import jakarta.activation.MimetypesFileTypeMap;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +47,7 @@ import org.springframework.util.StringUtils;
  * interface.
  */
 @SuppressWarnings("squid:S1135")
+@RequiredArgsConstructor
 public class DefaultFSReaderImpl extends AbstractDomibusConnectorClientFileSystemReaderImpl
     implements DomibusConnectorClientFileSystemReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultFSReaderImpl.class);
@@ -57,13 +57,13 @@ public class DefaultFSReaderImpl extends AbstractDomibusConnectorClientFileSyste
         "Found content pdf file with name {}";
     public static final String FOUND_DETACHED_SIGNATURE_FILE_WITH_NAME =
         "Found detached signature file with name {}";
-    @Autowired
-    private DomibusConnectorClientFSMessageProperties messageProperties;
-    @Autowired
-    private DomibusConnectorClientFSConfigurationProperties properties;
+
+    private final DomibusConnectorClientFSMessageProperties messageProperties;
+    private final DomibusConnectorClientFSConfigurationProperties properties;
 
     @Override
     public List<File> readUnsentMessages(File outgoingMessagesDir) {
+        Objects.requireNonNull(outgoingMessagesDir, "outgoingMessagesDir must not be null!");
         String messageReadyPostfix = properties.getMessageReadyPostfix();
         if (messageReadyPostfix == null) {
             messageReadyPostfix = "";
@@ -72,8 +72,9 @@ public class DefaultFSReaderImpl extends AbstractDomibusConnectorClientFileSyste
             "#readUnsentMessages: Searching for folders with ending {}", messageReadyPostfix);
         List<File> messagesUnsent = new ArrayList<>();
 
-        if (outgoingMessagesDir.listFiles().length > 0) {
-            for (var sub : outgoingMessagesDir.listFiles()) {
+        var outgoingMsgDirs = outgoingMessagesDir.listFiles();
+        if (outgoingMsgDirs != null) {
+            for (var sub : outgoingMsgDirs) {
                 if (sub.isDirectory()
                     && sub.getName().endsWith(messageReadyPostfix)) {
                     messagesUnsent.add(sub);
@@ -96,7 +97,7 @@ public class DefaultFSReaderImpl extends AbstractDomibusConnectorClientFileSyste
         Map<String, DomibusConnectorClientStorageFileType> files =
             new HashMap<>();
         if (messageFolder.exists() && messageFolder.isDirectory()
-            && messageFolder.listFiles().length > 0) {
+            && messageFolder.listFiles() != null) {
 
             var messageDetails =
                 new DefaultMessageProperties(messageFolder, this.messageProperties.getFileName());

--- a/client-application/client-app-fs-storage/src/main/java/eu/ecodex/connector/client/filesystem/standard/writer/DefaultFSWriterImpl.java
+++ b/client-application/client-app-fs-storage/src/main/java/eu/ecodex/connector/client/filesystem/standard/writer/DefaultFSWriterImpl.java
@@ -25,6 +25,8 @@ import eu.ecodex.connector.domain.transition.DomibusConnectorMessageType;
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
+
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,25 +36,17 @@ import org.springframework.util.StringUtils;
  * Represents an implementation of the {@link DomibusConnectorClientFileSystemWriter} interface.
  * This class is responsible for writing messages to the file system.
  */
+@RequiredArgsConstructor
 public class DefaultFSWriterImpl extends AbstractDomibusConnectorClientFileSystemWriterImpl
     implements DomibusConnectorClientFileSystemWriter {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultFSWriterImpl.class);
-    @Autowired
-    private DomibusConnectorClientFSMessageProperties messageProperties;
-    @Autowired
-    private DomibusConnectorClientFSConfigurationProperties properties;
+
+    private final DomibusConnectorClientFSMessageProperties messageProperties;
+    private final DomibusConnectorClientFSConfigurationProperties properties;
 
     private void storeMessagePropertiesToFile(
         DefaultMessageProperties messageProperties,
         File messagePropertiesFile) {
-        if (!messagePropertiesFile.exists()) {
-            try {
-                messagePropertiesFile.createNewFile();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-
         messageProperties.storeMessagePropertiesToFile(messagePropertiesFile);
     }
 
@@ -88,6 +82,8 @@ public class DefaultFSWriterImpl extends AbstractDomibusConnectorClientFileSyste
             msgProps = convertMessageDetailsToMessageProperties(
                 message
                     .getMessageDetails(), messageReceived);
+        } else {
+            throw new IllegalStateException("Cannot continue, because msgProps is null");
         }
 
         DomibusConnectorMessageContentType messageContent = message.getMessageContent();
@@ -157,42 +153,66 @@ public class DefaultFSWriterImpl extends AbstractDomibusConnectorClientFileSyste
             );
         }
         if (messageDetails.getToParty() != null) {
-            msgDetails.getMessageProperties().put(
-                messageProperties.getToPartyId(),
-                messageDetails.getToParty().getPartyId()
-            );
-            msgDetails.getMessageProperties().put(
-                messageProperties.getToPartyRole(),
-                messageDetails.getToParty().getRole()
-            );
+            if (messageDetails.getToParty().getPartyId() != null) {
+                msgDetails.getMessageProperties().put(
+                        messageProperties.getToPartyId(),
+                        messageDetails.getToParty().getPartyId()
+                );
+            } else {
+                throw new IllegalArgumentException("The partyId of ToParty is not allowed to be null!");
+            }
+            if (messageDetails.getToParty().getRole() != null) {
+                msgDetails.getMessageProperties().put(
+                        messageProperties.getToPartyRole(),
+                        messageDetails.getToParty().getRole()
+                );
+            }
         }
         if (messageDetails.getFromParty() != null) {
-            msgDetails.getMessageProperties().put(
-                messageProperties.getFromPartyId(),
-                messageDetails.getFromParty().getPartyId()
-            );
-            msgDetails.getMessageProperties().put(
-                messageProperties.getFromPartyRole(),
-                messageDetails.getFromParty().getRole()
-            );
+            if (messageDetails.getFromParty().getPartyId() != null) {
+                msgDetails.getMessageProperties().put(
+                        messageProperties.getFromPartyId(),
+                        messageDetails.getFromParty().getPartyId()
+                );
+            } else {
+                throw new IllegalArgumentException("The partyId of FromParty is not allowed to be null!");
+            }
+            if (messageDetails.getFromParty().getRole() != null) {
+                msgDetails.getMessageProperties().put(
+                        messageProperties.getFromPartyRole(),
+                        messageDetails.getFromParty().getRole()
+                );
+            }
+
         }
-        msgDetails.getMessageProperties()
-                  .put(messageProperties.getFinalRecipient(), messageDetails.getFinalRecipient());
-        msgDetails.getMessageProperties()
-                  .put(messageProperties.getOriginalSender(), messageDetails.getOriginalSender());
+        if (messageDetails.getFinalRecipient() != null) {
+            msgDetails.getMessageProperties()
+                    .put(messageProperties.getFinalRecipient(), messageDetails.getFinalRecipient());
+        }
+        if (messageDetails.getOriginalSender() != null) {
+            msgDetails.getMessageProperties()
+                    .put(messageProperties.getOriginalSender(), messageDetails.getOriginalSender());
+        }
+
         if (messageDetails.getAction() != null) {
             msgDetails.getMessageProperties()
                       .put(messageProperties.getAction(), messageDetails.getAction().getAction());
         }
         if (messageDetails.getService() != null) {
-            msgDetails.getMessageProperties().put(
-                messageProperties.getService(),
-                messageDetails.getService().getService()
-            );
-            msgDetails.getMessageProperties().put(
-                messageProperties.getServiceType(),
-                messageDetails.getService().getServiceType()
-            );
+            if (messageDetails.getService().getService() != null) {
+                msgDetails.getMessageProperties().put(
+                        messageProperties.getService(),
+                        messageDetails.getService().getService()
+                );
+            } else {
+                throw new IllegalArgumentException("The service of Service is not allowed to be null!");
+            }
+            if (messageDetails.getService().getServiceType() != null) {
+                msgDetails.getMessageProperties().put(
+                        messageProperties.getServiceType(),
+                        messageDetails.getService().getServiceType()
+                );
+            }
         }
         if (messageReceived != null) {
             msgDetails.getMessageProperties().put(


### PR DESCRIPTION
 (…cannot put a null value into java.util.Properties).

Additionally added some other NPE checks into the code.

The main problem is, that according to XML schema a serviceType is a optional value. So it can be null, but it is not allowed to put a null as a value into java.util.Properties.

I also worked on other potential problems on storing, loading messages. Just let me know if I should reduce the PR to the failure mentioned above.